### PR TITLE
feat: add contextual descriptions to catalog items and increase poste…

### DIFF
--- a/backend/src/modules/stremio/poster.service.ts
+++ b/backend/src/modules/stremio/poster.service.ts
@@ -35,8 +35,8 @@ export async function generateRatedPoster(
   const width = metadata.width ?? 300;
   const height = metadata.height ?? 450;
 
-  // Badge dimensions scaled to image size
-  const badgeW = Math.round(width * 0.22);
+  // Badge dimensions scaled to image size (increased)
+  const badgeW = Math.round(width * 0.28);
   const badgeH = Math.round(badgeW * 0.55);
   const margin = Math.round(width * 0.03);
   const fontSize = Math.round(badgeH * 0.58);


### PR DESCRIPTION
…r badge size

- Add diary entry descriptions with like status, personal rating, and date
- Add rank numbers to Top 250 and ranked custom lists
- Use global rating on Friends Activity posters instead of friend's rating
- Increase poster badge size from 22% to 28% for better visibility