### PR TITLE
Amélioration SEO technique : métadonnées, JSON‑LD et directives de crawl

### DIFF
--- a/src/app/configure/layout.tsx
+++ b/src/app/configure/layout.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Configure Stremio Letterboxd Addon",
+  description:
+    "Configure the Stremio Letterboxd addon, connect your account, choose watchlist and custom catalogs, and generate your install URL.",
+  alternates: {
+    canonical: "/configure",
+  },
+  openGraph: {
+    title: "Configure Stremio Letterboxd Addon",
+    description:
+      "Set up your Letterboxd watchlist, ratings, and lists in Stremio with a personalized addon configuration.",
+    url: "https://stremboxd.com/configure",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Configure Stremio Letterboxd Addon",
+    description: "Generate your personalized Letterboxd to Stremio addon manifest URL.",
+  },
+};
+
+export default function ConfigureLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,9 +12,51 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  title: "Letterboxd → Stremio Addon",
-  description: "Unofficial addon that syncs your Letterboxd data into Stremio",
-  keywords: ["letterboxd", "stremio", "addon", "movies", "watchlist"],
+  metadataBase: new URL("https://stremboxd.com"),
+  title: {
+    default: "Stremio Letterboxd Addon | Sync Watchlist, Ratings & Lists",
+    template: "%s | Stremboxd",
+  },
+  description:
+    "Install the Stremio Letterboxd addon to sync your Letterboxd watchlist, ratings, diary, liked films, and custom lists directly into Stremio.",
+  keywords: [
+    "stremio letterboxd addon",
+    "letterboxd watchlist stremio",
+    "sync letterboxd to stremio",
+    "letterboxd ratings in stremio",
+    "stremio movie metadata addon",
+    "letterboxd addon",
+    "stremio addon",
+  ],
+  alternates: {
+    canonical: "/",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-video-preview": -1,
+      "max-snippet": -1,
+    },
+  },
+  openGraph: {
+    title: "Stremio Letterboxd Addon | Sync Watchlist, Ratings & Lists",
+    description:
+      "Connect Letterboxd and Stremio to browse watchlists, ratings, diary entries, and curated lists in one addon.",
+    url: "https://stremboxd.com",
+    siteName: "Stremboxd",
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Stremio Letterboxd Addon",
+    description:
+      "Sync Letterboxd watchlist, ratings, diary, and lists into Stremio with one addon.",
+  },
   authors: [{ name: "esp4ce", url: "https://github.com/esp4ce" }],
   icons: {
     icon: "/favicon.svg",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,10 +11,67 @@ const FEATURES = [
   "Letterboxd links",
 ];
 
+const softwareApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Stremio Letterboxd Addon",
+  applicationCategory: "MultimediaApplication",
+  applicationSubCategory: "Movie Metadata Addon",
+  operatingSystem: "Stremio",
+  url: "https://stremboxd.com",
+  description:
+    "A Stremio movie metadata addon that syncs Letterboxd watchlist, ratings, diary, liked films, and custom lists.",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "How do I sync Letterboxd to Stremio?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Open the Stremio Letterboxd addon configuration page, connect your Letterboxd account or username, choose catalogs and lists, then install the generated addon manifest in Stremio.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Can I import my Letterboxd watchlist into Stremio?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. The addon can include your Letterboxd watchlist as a Stremio catalog so you can browse it directly in your Stremio library.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Does the addon show Letterboxd ratings in Stremio?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Yes. You can enable rating display so films in Stremio include your Letterboxd rating context.",
+      },
+    },
+  ],
+};
+
 export default function Home() {
   return (
-    <div className="fixed inset-0 flex h-[100dvh] w-screen cursor-default flex-col bg-[#0a0a0a] text-white sm:h-screen sm:items-center sm:justify-center">
-      <div className="flex min-h-0 flex-1 w-full max-w-7xl flex-col items-center justify-center overflow-y-auto px-4 sm:mx-auto sm:-mt-16 sm:flex-none sm:h-full sm:overflow-visible">
+    <main className="fixed inset-0 flex h-[100dvh] w-screen cursor-default flex-col bg-[#0a0a0a] text-white sm:h-screen sm:items-center sm:justify-center">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+
+      <section className="flex min-h-0 flex-1 w-full max-w-7xl flex-col items-center justify-center overflow-y-auto px-4 sm:mx-auto sm:-mt-16 sm:flex-none sm:h-full sm:overflow-visible">
         <h1 className="mt-10 text-center text-2xl font-semibold tracking-tight text-white sm:mt-0 sm:text-5xl lg:text-6xl xl:text-7xl">
           Letterboxd → Stremio Addon
         </h1>
@@ -57,7 +114,30 @@ export default function Home() {
           </a>{" "}
           to prioritize this addon for the best experience.
         </p>
-      </div>
+      </section>
+
+      <section aria-label="Stremio Letterboxd addon information" className="sr-only">
+        <h2>Sync Letterboxd to Stremio</h2>
+        <p>
+          Install this Stremio movie metadata addon to sync your Letterboxd watchlist, ratings, liked films, diary, and
+          custom lists.
+        </p>
+        <h2>How to install</h2>
+        <ol>
+          <li>Open the addon configuration page.</li>
+          <li>Connect your Letterboxd account or validate your public username.</li>
+          <li>Choose the catalogs and lists you want in Stremio.</li>
+          <li>Install the generated manifest in Stremio.</li>
+        </ol>
+        <h2>Frequently asked questions</h2>
+        <h3>How do I sync Letterboxd to Stremio?</h3>
+        <p>Use the configuration flow, generate your personal manifest URL, and install it in Stremio.</p>
+        <h3>Can I use my Letterboxd watchlist in Stremio?</h3>
+        <p>Yes. Enable Watchlist during setup and it appears as a catalog.</p>
+        <h3>Can I see Letterboxd ratings in Stremio?</h3>
+        <p>Yes. Enable ratings in your addon display options.</p>
+        <a href="/configure">Configure the Stremio Letterboxd addon</a>
+      </section>
 
       <div className="shrink-0 flex justify-center py-6 sm:absolute sm:bottom-12">
         <TransitionLink
@@ -81,6 +161,6 @@ export default function Home() {
           </svg>
         </TransitionLink>
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/dashboard"],
+    },
+    sitemap: "https://stremboxd.com/sitemap.xml",
+    host: "https://stremboxd.com",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://stremboxd.com/",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: "https://stremboxd.com/configure",
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+  ];
+}


### PR DESCRIPTION
### Motivation
- Améliorer la découvrabilité organique et l’éligibilité aux rich results pour les requêtes à forte intention autour de « Stremio ↔ Letterboxd » sans modifier l’UI ni le rendu visuel.
- Normaliser les signaux de crawl/indexation (canonical, robots, sitemap) et enrichir le contenu sémantique pour mieux correspondre aux requêtes fonctionnelles (watchlist, sync, ratings, metadata).

### Description
- Mise à jour du metadata global dans `src/app/layout.tsx` : `metadataBase`, `title` par défaut et template, meta description optimisée, liste de mots‑clés ciblés, alternates/canonical, directives `robots`, Open Graph et Twitter Cards.
- Ajout de métadonnées spécifiques à la route `/configure` dans `src/app/configure/layout.tsx` (title, description, canonical, OG/Twitter) pour mieux cibler la page de configuration.
- Amélioration sémantique de la homepage (`src/app/page.tsx`) sans changement visuel : passage à `<main>`/`<section>`, insertion d’un bloc SEO non visible (`className="sr-only"`) contenant étapes d’installation et FAQ, et ajout de JSON‑LD `SoftwareApplication` et `FAQPage` via `<script type="application/ld+json">`.
- Ajout de fichiers de pilotage de crawl : `src/app/robots.ts` (règles robots, déclaration du sitemap, disallow `/dashboard`) et `src/app/sitemap.ts` (liste prioritaire des URLs `/` et `/configure` avec fréquences et priorités).

### Testing
- `npm run lint` a été exécuté et s’est terminé sans erreurs fonctionnelles, avec 3 warnings existants hors des fichiers SEO modifiés.
- `npm run build` a été lancé mais a échoué dans cet environnement à cause d’un problème externe de récupération des Google Fonts (`next/font` n’a pas pu télécharger `Inter` depuis `fonts.googleapis.com`).
- Les changements sont limités aux métadonnées et au balisage sémantique de la page d’accueil et de la page de configuration, et n’impactent pas le style ni le rendu visuel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699476c306988320b3984eb94226483b)