### PR TITLE
fix: normalizeSlug ignoring apostrophes to prevent 404 on lists

### DIFF
--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -310,6 +310,7 @@ export async function authRoutes(app: FastifyInstance) {
 
         const normalizeSlug = (name: string) =>
           name.toLowerCase()
+            .replace(/['’]/g, '')
             .replace(/[^a-z0-9]+/g, '-')
             .replace(/^-|-$/g, '');
 


### PR DESCRIPTION
## Description
When attempting to add certain public lists, the API returns a `404 List not found` error. This happens specifically when the HTML scraping strategy (Strategy 1) fails and the code falls back to the API pagination search (Strategy 2) for a list that contains an apostrophe in its title.

## Stepts to Reproduce
Try to resolve a list that has an apostrophe in its name, for example:
`https://letterboxd.com/brsan/list/letterboxds-top-250-international-films/`
*(The actual list name on Letterboxd is "Letterboxd’s Top 250 International Films")*

## Root Cause
The issue lies in the `normalizeSlug` function inside `auth.routes.ts`.

```typescript
const normalizeSlug = (name: string) =>
  name.toLowerCase()
    .replace(/[^a-z0-9]+/g, '-')
    .replace(/^-|-$/g, '');
 ```
When Letterboxd generates a slug for a list with an apostrophe, it completely removes the apostrophe. Thus, `"Letterboxd’s"` becomes `letterboxds`.

However, the current `normalizeSlug` function treats the apostrophe as a non-alphanumeric character and replaces it with a hyphen, turning it into `letterboxd-s`. Because `letterboxds... !== letterboxd-s...`, the comparison fails, the loop exhausts all the user's lists, and it incorrectly returns a 404 error.

We can easily fix this by stripping straight and curly apostrophes before applying the hyphenation regex:
```typescript
const normalizeSlug = (name: string) =>
  name.toLowerCase()
    .replace(/['’]/g, '') // Strips apostrophes first
    .replace(/[^a-z0-9]+/g, '-')
    .replace(/^-|-$/g, '');
```