### PR TITLE
feat: add SEO infrastructure (robots.txt, sitemap, OG, JSON-LD, meta …

### DIFF
--- a/src/app/configure/layout.tsx
+++ b/src/app/configure/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Configure Your Addon",
+  description:
+    "Connect your Letterboxd account to Stremio in seconds. Configure your watchlist, ratings, diary and custom lists.",
+  alternates: { canonical: "/configure" },
+};
+
+export default function ConfigureLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return children;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,14 +11,53 @@ const inter = Inter({
   display: "swap",
 });
 
+const SITE_TITLE = "Stremboxd – Sync Letterboxd with Stremio";
+const SITE_DESCRIPTION =
+  "Sync your Letterboxd watchlist, ratings, diary and lists with Stremio. Free unofficial addon for all platforms.";
+
 export const metadata: Metadata = {
-  title: "Letterboxd → Stremio Addon",
-  description: "Unofficial addon that syncs your Letterboxd data into Stremio",
-  keywords: ["letterboxd", "stremio", "addon", "movies", "watchlist"],
+  metadataBase: new URL("https://stremboxd.com"),
+  title: {
+    default: `${SITE_TITLE} | Watchlist, Ratings & Lists`,
+    template: "%s | Stremboxd",
+  },
+  description: SITE_DESCRIPTION,
+  keywords: [
+    "stremboxd",
+    "letterboxd",
+    "stremio",
+    "addon",
+    "stremio addon",
+    "letterboxd stremio",
+    "movies",
+    "watchlist",
+    "film ratings",
+    "diary",
+    "sync",
+    "streaming",
+    "media center",
+  ],
   authors: [{ name: "esp4ce", url: "https://github.com/esp4ce" }],
+  creator: "esp4ce",
   icons: {
     icon: "/favicon.svg",
     apple: "/favicon.svg",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: "https://stremboxd.com",
+    siteName: "Stremboxd",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  alternates: {
+    canonical: "/",
   },
 };
 
@@ -26,6 +65,26 @@ export const viewport: Viewport = {
   themeColor: "#0a0a0a",
   width: "device-width",
   initialScale: 1,
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Stremboxd",
+  applicationCategory: "MultimediaApplication",
+  operatingSystem: "All",
+  description: SITE_DESCRIPTION,
+  url: "https://stremboxd.com",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  author: {
+    "@type": "Person",
+    name: "esp4ce",
+    url: "https://github.com/esp4ce",
+  },
 };
 
 export default function RootLayout({
@@ -36,6 +95,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} ${inter.className} antialiased`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <Analytics />
         <ConsoleMessage />
         {children}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,100 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export const alt = "Stremboxd – Sync Letterboxd with Stremio";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          padding: "60px",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "24px",
+          }}
+        >
+          <h1
+            style={{
+              fontSize: "72px",
+              fontWeight: 700,
+              color: "#ffffff",
+              textAlign: "center",
+              lineHeight: 1.1,
+              margin: 0,
+            }}
+          >
+            Stremboxd
+          </h1>
+
+          <p
+            style={{
+              fontSize: "32px",
+              fontWeight: 300,
+              color: "#a1a1aa",
+              textAlign: "center",
+              margin: 0,
+            }}
+          >
+            Sync Letterboxd with Stremio
+          </p>
+
+          <div
+            style={{
+              display: "flex",
+              gap: "16px",
+              marginTop: "32px",
+            }}
+          >
+            {["Watchlist", "Ratings", "Diary", "Lists"].map((label) => (
+              <div
+                key={label}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "8px",
+                  backgroundColor: "#18181b",
+                  border: "1px solid #27272a",
+                  borderRadius: "12px",
+                  padding: "12px 24px",
+                }}
+              >
+                <span style={{ fontSize: "20px", color: "#d4d4d8" }}>
+                  {label}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <p
+          style={{
+            position: "absolute",
+            bottom: "40px",
+            fontSize: "20px",
+            color: "#52525b",
+            margin: 0,
+          }}
+        >
+          stremboxd.com
+        </p>
+      </div>
+    ),
+    size
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/configure"],
+        disallow: ["/dashboard"],
+      },
+    ],
+    sitemap: "https://stremboxd.com/sitemap.xml",
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://stremboxd.com",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: "https://stremboxd.com/configure",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
…tags)

Add technical SEO without changing the visible design:
- robots.txt allowing crawlers on public pages, blocking /dashboard
- sitemap.xml for Google discovery
- Dynamic OG image (1200x630) for social sharing previews
- Open Graph and Twitter Card meta tags
- JSON-LD SoftwareApplication structured data for rich snippets
- Canonical URLs and metadataBase
- Page-specific metadata for / and /configure
- Enriched keywords targeting relevant search terms