### PR TITLE
Security hardening: SSRF fix, rate limits, postcss override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [integration, main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests backend

--- a/backend/src/lib/html-scraper.ts
+++ b/backend/src/lib/html-scraper.ts
@@ -39,8 +39,18 @@ const LIST_SHORTLINK_TAG_ALT_REGEX = /href="https?:\/\/boxd\.it\/([A-Za-z0-9]+)"
 const LIST_LIKEABLE_IDENTIFIER_REGEX =
   /data-likeable-identifier='([^']+)'/;
 
+const ALLOWED_HOSTS = new Set(['letterboxd.com', 'www.letterboxd.com', 'boxd.it']);
+
 export async function fetchPageHtml(url: string): Promise<string | null> {
-  return curlFetch(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+  if (!ALLOWED_HOSTS.has(parsed.hostname)) return null;
+  return curlFetch(parsed.toString());
 }
 
 export function extractBoxdShortlinkId(html: string): string | null {

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -16,3 +16,13 @@ export const loginRateLimit = {
   max: 3,
   timeWindow: '1 minute',
 };
+
+export const actionRateLimit = {
+  max: 30,
+  timeWindow: '1 minute',
+};
+
+export const preferencesRateLimit = {
+  max: 20,
+  timeWindow: '1 minute',
+};

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -186,7 +186,7 @@ export async function authRoutes(app: FastifyInstance) {
   // ═══════════════════════════════════════════════════════════════════════════
 
   const validateUsernameSchema = z.object({
-    username: z.string().min(1).max(100),
+    username: z.string().min(1).max(15).regex(/^[a-zA-Z0-9_-]+$/),
   });
 
   app.post(

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -8,7 +8,7 @@ import {
   updateUserPreferences,
   upsertTier1User,
 } from '../../db/repositories/user.repository.js';
-import { loginRateLimit } from '../../middleware/rate-limit.js';
+import { loginRateLimit, preferencesRateLimit } from '../../middleware/rate-limit.js';
 import { trackEvent } from '../../lib/metrics.js';
 import { callWithAppToken } from '../../lib/app-client.js';
 import {
@@ -139,6 +139,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/preferences',
     {
+      config: { rateLimit: preferencesRateLimit },
       schema: {
         body: {
           type: 'object',

--- a/backend/src/modules/letterboxd/letterboxd.service.ts
+++ b/backend/src/modules/letterboxd/letterboxd.service.ts
@@ -125,7 +125,7 @@ export interface ParsedListUrl {
 export function parseLetterboxdListUrl(input: string): ParsedListUrl | null {
   // Match URLs like: https://letterboxd.com/username/list/slug-name/
   const match = input.match(
-    /(?:https?:\/\/)?(?:www\.)?letterboxd\.com\/([^/]+)\/list\/([^/]+)/
+    /(?:https?:\/\/)?(?:www\.)?letterboxd\.com\/([a-zA-Z0-9_-]+)\/list\/([a-zA-Z0-9_-]+)/
   );
   if (!match) return null;
   return { username: match[1]!, slug: match[2]! };

--- a/backend/src/modules/stremio/stremio.routes.ts
+++ b/backend/src/modules/stremio/stremio.routes.ts
@@ -22,6 +22,7 @@ import {
   getPopularReviewsText,
 } from './meta.service.js';
 import { generateRatedPoster } from './poster.service.js';
+import { actionRateLimit } from '../../middleware/rate-limit.js';
 import { createChildLogger } from '../../lib/logger.js';
 import {
   imdbToLetterboxdCache,
@@ -538,7 +539,7 @@ export async function stremioRoutes(app: FastifyInstance) {
 
   app.get(
     '/action/:userId/:action/:filmId',
-    { schema: { params: actionParamsSchema } },
+    { config: { rateLimit: actionRateLimit }, schema: { params: actionParamsSchema } },
     async (
       request: FastifyRequest<{
         Params: { userId: string; action: string; filmId: string };
@@ -615,7 +616,7 @@ export async function stremioRoutes(app: FastifyInstance) {
 
   app.get(
     '/action/:userId/rate/:filmId',
-    { schema: { params: rateParamsSchema } },
+    { config: { rateLimit: actionRateLimit }, schema: { params: rateParamsSchema } },
     async (
       request: FastifyRequest<{
         Params: { userId: string; filmId: string };
@@ -662,7 +663,7 @@ export async function stremioRoutes(app: FastifyInstance) {
 
   app.get(
     '/action/:userId/rate/:filmId/submit',
-    { schema: { params: rateParamsSchema } },
+    { config: { rateLimit: actionRateLimit }, schema: { params: rateParamsSchema } },
     async (
       request: FastifyRequest<{
         Params: { userId: string; filmId: string };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stremio-letterboxd-addons",
-  "version": "1.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stremio-letterboxd-addons",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -5704,34 +5704,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -5998,10 +5970,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- **SSRF fix**: validate URLs in `fetchPageHtml` (hostname allowlist) + tighten regex on username/list slug inputs (closes 3 CodeQL `js/request-forgery` alerts)
- **Rate limits**: explicit per-route rate limits on `/action/*` (30/min) and `/auth/preferences` (20/min) — closes 5 CodeQL `js/missing-rate-limiting` alerts
- **CI hardening**: restrict `GITHUB_TOKEN` permissions to `contents: read` (closes CodeQL alert)
- **postcss XSS**: override transitive `postcss` to `^8.5.10` (GHSA-qx2v-qp2m-jg93)

## Test plan
- [x] `npm run test:run` — 305/305 backend tests pass
- [x] `npm run lint` — no errors
- [x] `npm run build` (frontend) — succeeds with postcss override
- [x] `npm audit` (frontend) — 0 vulnerabilities