### PR TITLE
fix(security): resolve CodeQL alerts and clean GitHub repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 /node_modules
 /.pnp

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -192,6 +192,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/validate-username',
     {
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',
@@ -253,6 +254,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/resolve-list-public',
     {
+      config: { rateLimit: { max: 5, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',
@@ -403,6 +405,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/resolve-contributor-public',
     {
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',

--- a/backend/src/modules/stremio/meta.service.ts
+++ b/backend/src/modules/stremio/meta.service.ts
@@ -505,17 +505,33 @@ export async function getPopularReviewsText(
     if (reviews.length === 0) return null;
 
     const lines = reviews.map(r => {
-      // Strip HTML tags from review text (loop until stable to avoid bypass via re-emerging sequences)
+      // Extract plain text from HTML review, removing tags and decoding entities
       let text = r.review!.text!;
-      let prev: string;
-      do {
-        prev = text;
-        text = text
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<script[^>]*>/gi, '')
-          .replace(/<[^>]+>/g, '');
-      } while (text !== prev);
-      text = text.replace(/\n+/g, ' ').trim();
+
+      // Remove script and style tags with their content
+      text = text.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ');
+      text = text.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ');
+
+      // Replace all other HTML tags with space
+      text = text.replace(/<[^>]+>/g, ' ');
+
+      // Decode common HTML entities
+      const entities: Record<string, string> = {
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&quot;': '"',
+        '&#39;': "'",
+        '&apos;': "'",
+        '&nbsp;': ' ',
+      };
+      for (const [entity, char] of Object.entries(entities)) {
+        text = text.split(entity).join(char);
+      }
+
+      // Collapse multiple spaces and trim
+      text = text.replace(/\s+/g, ' ').trim();
+
       if (text.length > 150) text = text.slice(0, 147) + '...';
       const stars = r.rating ? ' ' + formatStars(r.rating, false) : '';
       const author = r.owner.displayName || r.owner.username;

--- a/backend/src/modules/stremio/meta.service.ts
+++ b/backend/src/modules/stremio/meta.service.ts
@@ -481,6 +481,20 @@ export async function buildLetterboxdStreams(
 // ============================================================================
 
 /**
+ * HTML entities mapping for decoding common named entities.
+ * Numeric entities (&#x...; and &#...;) are handled separately via regex.
+ */
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+  '&nbsp;': ' ',
+};
+
+/**
  * Fetch popular reviews for a film and format them for the meta description.
  * Returns a formatted string with up to 2 non-spoiler reviews, or null if none.
  */
@@ -515,21 +529,15 @@ export async function getPopularReviewsText(
       // Replace all other HTML tags with space
       text = text.replace(/<[^>]+>/g, ' ');
 
-      // Decode common HTML entities
-      const entities: Record<string, string> = {
-        '&amp;': '&',
-        '&lt;': '<',
-        '&gt;': '>',
-        '&quot;': '"',
-        '&#39;': "'",
-        '&apos;': "'",
-        '&nbsp;': ' ',
-      };
-      for (const [entity, char] of Object.entries(entities)) {
+      // Decode numeric HTML entities (hex and decimal)
+      text = text.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+      text = text.replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)));
+
+      // Decode named HTML entities
+      for (const [entity, char] of Object.entries(HTML_ENTITIES)) {
         text = text.split(entity).join(char);
       }
 
-      // Collapse multiple spaces and trim
       text = text.replace(/\s+/g, ' ').trim();
 
       if (text.length > 150) text = text.slice(0, 147) + '...';


### PR DESCRIPTION
## Summary

- Replace regex-based HTML stripping in `meta.service.ts` with a safe linear approach (fixes CodeQL #12, #13, #14)
- Add numeric HTML entity decoding (`&#NNNN;`, `&#xNNNN;`) for smart quotes, em-dashes, etc.
- Add rate limiting to `/auth/validate-username` (10/min), `/auth/resolve-list-public` (5/min), `/auth/resolve-contributor-public` (10/min)
- Dismiss 7 false-positive CodeQL alerts (SSRF already guarded by `assertAllowedUrl`, Fastify rate-limit config not recognized by CodeQL)

## Test Plan

- [x] All 305 backend tests pass
- [x] TypeScript builds clean
- [x] CodeQL false positives dismissed in GitHub Security