### PR TITLE
chore(deps): merge validated dependency bumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 /node_modules
 /.pnp

--- a/README.md
+++ b/README.md
@@ -1,35 +1,63 @@
+<div align="center">
+
 # Stremboxd
 
-Unofficial Stremio addon that syncs your Letterboxd data — watchlist, diary, friends, lists, and more.
+**Bring your Letterboxd life into Stremio.**  
+Watchlist, diary, friends, lists, ratings — all in one addon.
 
-[stremboxd.com](https://stremboxd.com) · [Configure](https://stremboxd.com/configure) · [FAQ](https://stremboxd.com/faq)
+[![CI](https://github.com/esp4ce/stremio-letterboxd-addon/actions/workflows/ci.yml/badge.svg)](https://github.com/esp4ce/stremio-letterboxd-addon/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![Stremio](https://img.shields.io/badge/Stremio-addon-8A05BE?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyek0xMCAxNi41di05bDYgNC41LTYgNC41eiIvPjwvc3ZnPg==)](https://stremboxd.com/configure)
+
+[**Configure →**](https://stremboxd.com/configure) · [Website](https://stremboxd.com) · [FAQ](https://stremboxd.com/faq)
+
+<!-- Replace with an actual screenshot or GIF of the addon in Stremio -->
+<!-- ![Stremboxd in action](docs/preview.gif) -->
+
+</div>
+
+---
 
 ## Features
 
-- Watchlist, diary & friends activity
-- Custom & private lists
-- Genre, decade & sort filters
-- Search Letterboxd films from Stremio
-- Ratings displayed on every film
-- Rate, like & toggle watched from Stremio
-- 2FA support
-- All platforms
+- **Watchlist** — your full Letterboxd watchlist, always in sync
+- **Diary** — recently watched films, pulled straight from your diary
+- **Friends activity** — see what people you follow are watching
+- **Custom & private lists** — any Letterboxd list by URL or shortlink
+- **Ratings on every poster** — your score displayed directly in Stremio
+- **Quick actions** — rate, like, and toggle watched without leaving Stremio
+- **Genre, decade & sort filters** — narrow down any catalog instantly
+- **Search** — find Letterboxd films from the Stremio search bar
+- **2FA support** — works with accounts that have two-factor authentication
+- **All platforms** — Stremio web, desktop, Android, iOS, TV
 
-## Two ways to use it
+## Two modes
 
-**Public mode** — Enter your username, no login needed.
-Access popular films, Top 250, your public watchlist, and custom lists.
+| | Public mode | Full mode |
+|---|---|---|
+| **Setup** | Username only, no login | Login with Letterboxd credentials |
+| **Watchlist** | Public watchlist | Public + private |
+| **Diary** | — | ✓ |
+| **Friends** | — | ✓ |
+| **Quick actions** | — | ✓ |
+| **Custom lists** | ✓ | ✓ |
+| **Popular / Top 250** | ✓ | ✓ |
 
-**Full mode** — Log in with your Letterboxd credentials.
-Unlock diary, friends activity, and quick actions (rate, like, toggle watched) directly from Stremio.
+## Get started
 
-## How it works
-
-Configure your addon at [stremboxd.com/configure](https://stremboxd.com/configure), then install it in Stremio. Use [Stremio Addon Manager](https://stremio-addon-manager.vercel.app/) to prioritize it for the best experience.
+1. Go to [stremboxd.com/configure](https://stremboxd.com/configure)
+2. Choose Public or Full mode and configure your preferences
+3. Click **Install in Stremio**
+4. _(Optional)_ Use [Stremio Addon Manager](https://stremio-addon-manager.vercel.app/) to prioritize the addon for best results
 
 ## Stack
 
-Next.js · React · Tailwind CSS · Fastify · SQLite
+| Layer | Tech |
+|---|---|
+| Frontend | Next.js 16, React 19, Tailwind CSS 4 |
+| Backend | Fastify 5, TypeScript, SQLite |
+| Auth | JWT (Jose), AES-256-GCM encrypted tokens |
+| Tests | Vitest, MSW |
 
 ## Support
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,7 @@
         "lru-cache": "^10.0.0",
         "pino": "^9.0.0",
         "pino-pretty": "^11.0.0",
-        "posthog-node": "^5.30.6",
+        "posthog-node": "^5.33.2",
         "sharp": "^0.34.5",
         "zod": "^3.23.0"
       },
@@ -26,7 +26,7 @@
         "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^4.1.5",
-        "msw": "^2.13.6",
+        "msw": "^2.14.3",
         "tsx": "^4.0.0",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
@@ -1343,18 +1343,18 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.7",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.7.tgz",
-      "integrity": "sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.2.tgz",
+      "integrity": "sha512-Dii3pxDheG1WioztvV/MqHQMnb16jSFrl2HkDR1T5yf5/R7lPqJCFYt+eXkEdp/oAv/PD+1joyG6Ap/2quFmtQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.372.3"
+        "@posthog/types": "1.372.8"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.372.3",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.3.tgz",
-      "integrity": "sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==",
+      "version": "1.372.8",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.8.tgz",
+      "integrity": "sha512-ALpfCnWsMSM9Cw/6kyLPVpd81ZReEdZwmDxOi+DTJuIo7wDxBiu2cAsjOuA6D/AL22v7HOJrHsmBAPAWqS5X7Q==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3016,9 +3016,9 @@
       }
     },
     "node_modules/msw": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.6.tgz",
-      "integrity": "sha512-GAJbQy8Ra/Ydjt0Hb2MGT2qhzd83J3+QZMHdH85uW7r/XkKc846+Ma2PLif5hGvTm5Yqa+wkcstpim0WeLZU9g==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
+      "integrity": "sha512-kk8G5cocVlJ4wsKMGZegn2H6XLOEKjbA+nSJE2354e/SRp4mDicCHUYnMXpymzVcVDCs+GUAsmNqSn+yHv4T2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3034,7 +3034,7 @@
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
-        "rettime": "^0.11.7",
+        "rettime": "^0.11.11",
         "statuses": "^2.0.2",
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.1",
@@ -3288,12 +3288,12 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "5.30.6",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.30.6.tgz",
-      "integrity": "sha512-deZuSiLkpdEipiywkww1FhQoKpVVFmJP6SAVQcZcMbugTLwJRYSGjgm+qV0Y91xghf2yP6Nr5Plfl52i9Qj15Q==",
+      "version": "5.33.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.33.2.tgz",
+      "integrity": "sha512-QZOT2uoEue4BGh/mrBUc7zfddtuLgCU7tTmW0MH8sTr8iK6argv82M7pQbJP/ENsiRYZa/ojpOIjTM9vO1xa6Q==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "1.27.7"
+        "@posthog/core": "1.28.2"
       },
       "engines": {
         "node": "^20.20.0 || >=22.22.0"
@@ -3463,9 +3463,9 @@
       }
     },
     "node_modules/rettime": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
-      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
+      "integrity": "sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.11",
-        "@types/node": "^22.0.0",
+        "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
         "msw": "^2.14.3",
         "tsx": "^4.0.0",
@@ -1750,13 +1750,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/set-cookie-parser": {
@@ -4050,9 +4050,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,7 @@
         "jose": "^5.0.0",
         "lru-cache": "^10.0.0",
         "pino": "^9.0.0",
-        "pino-pretty": "^11.0.0",
+        "pino-pretty": "^13.0.0",
         "posthog-node": "^5.33.2",
         "sharp": "^0.34.5",
         "zod": "^3.23.0"
@@ -1920,18 +1920,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -2138,30 +2126,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/chai": {
@@ -2417,24 +2381,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -2455,9 +2401,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
       "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
@@ -3207,35 +3153,37 @@
       }
     },
     "node_modules/pino-pretty": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-11.3.0.tgz",
-      "integrity": "sha512-oXwn7ICywaZPHmu3epHGU2oJX4nPmKvHvB/bwrJHlGcbEWaVcotkpyVHMKLKmiVryWYByNp0jpgAcXpFJDXJzA==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
-        "fast-copy": "^3.0.2",
+        "fast-copy": "^4.0.0",
         "fast-safe-stringify": "^2.1.1",
         "help-me": "^5.0.0",
         "joycon": "^3.1.1",
         "minimist": "^1.2.6",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
+        "pino-abstract-transport": "^3.0.0",
         "pump": "^3.0.0",
-        "readable-stream": "^4.0.0",
-        "secure-json-parse": "^2.4.0",
+        "secure-json-parse": "^4.0.0",
         "sonic-boom": "^4.0.1",
-        "strip-json-comments": "^3.1.1"
+        "strip-json-comments": "^5.0.2"
       },
       "bin": {
         "pino-pretty": "bin.js"
       }
     },
-    "node_modules/pino-pretty/node_modules/secure-json-parse": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
-      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
-      "license": "BSD-3-Clause"
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
     },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
@@ -3319,15 +3267,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -3382,22 +3321,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/real-require": {
@@ -3806,12 +3729,12 @@
       }
     },
     "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.2",
       "dependencies": {
         "@esp4ce/letterboxd-client": "^1.5.0",
-        "@fastify/cors": "^10.0.0",
+        "@fastify/cors": "^11.2.0",
         "@fastify/rate-limit": "^10.0.0",
         "better-sqlite3": "^12.9.0",
         "dotenv": "^17.4.2",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@fastify/cors": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-10.1.0.tgz",
-      "integrity": "sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+      "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
       "funding": [
         {
           "type": "github",
@@ -590,7 +590,7 @@
       "license": "MIT",
       "dependencies": {
         "fastify-plugin": "^5.0.0",
-        "mnemonist": "0.40.0"
+        "toad-cache": "^3.7.0"
       }
     },
     "node_modules/@fastify/error": {
@@ -3006,15 +3006,6 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
-    "node_modules/mnemonist": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.0.tgz",
-      "integrity": "sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==",
-      "license": "MIT",
-      "dependencies": {
-        "obliterator": "^2.0.4"
-      }
-    },
     "node_modules/msw": {
       "version": "2.14.3",
       "resolved": "https://registry.npmjs.org/msw/-/msw-2.14.3.tgz",
@@ -3113,12 +3104,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/obliterator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
-      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
-      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,7 @@
     "lru-cache": "^10.0.0",
     "pino": "^9.0.0",
     "pino-pretty": "^11.0.0",
-    "posthog-node": "^5.30.6",
+    "posthog-node": "^5.33.2",
     "sharp": "^0.34.5",
     "zod": "^3.23.0"
   },
@@ -29,7 +29,7 @@
     "@types/better-sqlite3": "^7.6.11",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.5",
-    "msw": "^2.13.6",
+    "msw": "^2.14.3",
     "tsx": "^4.0.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@esp4ce/letterboxd-client": "^1.5.0",
-    "@fastify/cors": "^10.0.0",
+    "@fastify/cors": "^11.2.0",
     "@fastify/rate-limit": "^10.0.0",
     "better-sqlite3": "^12.9.0",
     "dotenv": "^17.4.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.5",
     "msw": "^2.14.3",
     "tsx": "^4.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "jose": "^5.0.0",
     "lru-cache": "^10.0.0",
     "pino": "^9.0.0",
-    "pino-pretty": "^11.0.0",
+    "pino-pretty": "^13.0.0",
     "posthog-node": "^5.33.2",
     "sharp": "^0.34.5",
     "zod": "^3.23.0"

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -192,6 +192,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/validate-username',
     {
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',
@@ -253,6 +254,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/resolve-list-public',
     {
+      config: { rateLimit: { max: 5, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',
@@ -403,6 +405,7 @@ export async function authRoutes(app: FastifyInstance) {
   app.post(
     '/auth/resolve-contributor-public',
     {
+      config: { rateLimit: { max: 10, timeWindow: '1 minute' } },
       schema: {
         body: {
           type: 'object',

--- a/backend/src/modules/stremio/meta.service.ts
+++ b/backend/src/modules/stremio/meta.service.ts
@@ -505,17 +505,33 @@ export async function getPopularReviewsText(
     if (reviews.length === 0) return null;
 
     const lines = reviews.map(r => {
-      // Strip HTML tags from review text (loop until stable to avoid bypass via re-emerging sequences)
+      // Extract plain text from HTML review, removing tags and decoding entities
       let text = r.review!.text!;
-      let prev: string;
-      do {
-        prev = text;
-        text = text
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<script[^>]*>/gi, '')
-          .replace(/<[^>]+>/g, '');
-      } while (text !== prev);
-      text = text.replace(/\n+/g, ' ').trim();
+
+      // Remove script and style tags with their content
+      text = text.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, ' ');
+      text = text.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, ' ');
+
+      // Replace all other HTML tags with space
+      text = text.replace(/<[^>]+>/g, ' ');
+
+      // Decode common HTML entities
+      const entities: Record<string, string> = {
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&quot;': '"',
+        '&#39;': "'",
+        '&apos;': "'",
+        '&nbsp;': ' ',
+      };
+      for (const [entity, char] of Object.entries(entities)) {
+        text = text.split(entity).join(char);
+      }
+
+      // Collapse multiple spaces and trim
+      text = text.replace(/\s+/g, ' ').trim();
+
       if (text.length > 150) text = text.slice(0, 147) + '...';
       const stars = r.rating ? ' ' + formatStars(r.rating, false) : '';
       const author = r.owner.displayName || r.owner.username;

--- a/backend/src/modules/stremio/meta.service.ts
+++ b/backend/src/modules/stremio/meta.service.ts
@@ -481,6 +481,20 @@ export async function buildLetterboxdStreams(
 // ============================================================================
 
 /**
+ * HTML entities mapping for decoding common named entities.
+ * Numeric entities (&#x...; and &#...;) are handled separately via regex.
+ */
+const HTML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'",
+  '&apos;': "'",
+  '&nbsp;': ' ',
+};
+
+/**
  * Fetch popular reviews for a film and format them for the meta description.
  * Returns a formatted string with up to 2 non-spoiler reviews, or null if none.
  */
@@ -515,21 +529,15 @@ export async function getPopularReviewsText(
       // Replace all other HTML tags with space
       text = text.replace(/<[^>]+>/g, ' ');
 
-      // Decode common HTML entities
-      const entities: Record<string, string> = {
-        '&amp;': '&',
-        '&lt;': '<',
-        '&gt;': '>',
-        '&quot;': '"',
-        '&#39;': "'",
-        '&apos;': "'",
-        '&nbsp;': ' ',
-      };
-      for (const [entity, char] of Object.entries(entities)) {
+      // Decode numeric HTML entities (hex and decimal)
+      text = text.replace(/&#x([0-9a-fA-F]+);/g, (_, h) => String.fromCodePoint(parseInt(h, 16)));
+      text = text.replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)));
+
+      // Decode named HTML entities
+      for (const [entity, char] of Object.entries(HTML_ENTITIES)) {
         text = text.split(entity).join(char);
       }
 
-      // Collapse multiple spaces and trim
       text = text.replace(/\s+/g, ' ').trim();
 
       if (text.length > 150) text = text.slice(0, 147) + '...';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@vercel/analytics": "^2.0.1",
         "next": "^16.2.4",
-        "posthog-js": "^1.372.3",
+        "posthog-js": "^1.372.8",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "recharts": "^2.15.0"
@@ -1541,18 +1541,18 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.7",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.7.tgz",
-      "integrity": "sha512-6rzOZajUkhuezgPeF+ReMMly0D9oiwIZtMQrsJtZcS/mwi5OtvuYgxeaohgP9PKOhkK1c7cvGskX0Y2YUtBYCw==",
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.2.tgz",
+      "integrity": "sha512-Dii3pxDheG1WioztvV/MqHQMnb16jSFrl2HkDR1T5yf5/R7lPqJCFYt+eXkEdp/oAv/PD+1joyG6Ap/2quFmtQ==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.372.3"
+        "@posthog/types": "1.372.8"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.372.3",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.3.tgz",
-      "integrity": "sha512-4mkXC9AhsquJnvogWtWsCi+ReODj/jbK0d3fkwCNLLTOpaiAF125FJ6OJyRFax2u+dEKXAPA/dCTGx1S2WF0nw==",
+      "version": "1.372.8",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.8.tgz",
+      "integrity": "sha512-ALpfCnWsMSM9Cw/6kyLPVpd81ZReEdZwmDxOi+DTJuIo7wDxBiu2cAsjOuA6D/AL22v7HOJrHsmBAPAWqS5X7Q==",
       "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
@@ -6095,9 +6095,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.372.3",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.3.tgz",
-      "integrity": "sha512-CpKWMt6RkgY4lPpyvYzKcilKKB5VhL2gmS8HgibxmXZkEk/2rUxrEtRMScH8xi4n5WDaNSluCo87dh9yo9zArQ==",
+      "version": "1.372.8",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.8.tgz",
+      "integrity": "sha512-NAFWVScFGnU5jgGNLkrY/UnGH82uULs9RsJ/f26LkLn1l0MOZfq+/z+2RaOOQQX4NHruIVuxqz3J/50bgRG68A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -6105,8 +6105,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.27.7",
-        "@posthog/types": "1.372.3",
+        "@posthog/core": "1.28.2",
+        "@posthog/types": "1.372.8",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@vercel/analytics": "^2.0.1",
     "next": "^16.2.4",
-    "posthog-js": "^1.372.3",
+    "posthog-js": "^1.372.8",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "recharts": "^2.15.0"

--- a/src/app/components/ConsoleMessage.tsx
+++ b/src/app/components/ConsoleMessage.tsx
@@ -12,7 +12,7 @@ const CONSOLE_STYLES = {
 
 const CONSOLE_LINKS = [
   { label: "GitHub", url: "https://github.com/esp4ce" },
-  { label: "Reddit", url: "https://www.reddit.com/r/StremioAddons/", desc: "(Support & Community)" },
+  { label: "Reddit", url: "https://www.reddit.com/r/stremboxd/", desc: "(Support & Community)" },
   { label: "Support", url: "https://buymeacoffee.com/esp4ce", desc: "(Buy me a coffee)" },
 ];
 

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,6 +1,6 @@
 const LINKS = [
   { href: "https://github.com/esp4ce", label: "esp4ce" },
-  { href: "https://www.reddit.com/r/StremioAddons/", label: "reddit" },
+  { href: "https://www.reddit.com/r/stremboxd/", label: "reddit" },
   { href: "https://buymeacoffee.com/esp4ce", label: "support me" },
 ];
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+import TransitionLink from "./components/TransitionLink";
+import Footer from "./components/Footer";
+
+export default function NotFound() {
+  return (
+    <div className="fixed inset-0 flex h-[100dvh] w-screen flex-col items-center justify-center bg-[#0a0a0a] text-white">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <TransitionLink href="/" direction="down" className="text-7xl font-semibold tracking-tight sm:text-9xl transition-opacity hover:opacity-70">
+          404
+        </TransitionLink>
+        <p className="text-lg font-light text-zinc-400 sm:text-xl">
+          ★½ — Didn&apos;t finish it.
+        </p>
+        <a
+          href="https://buymeacoffee.com/esp4ce"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 text-sm font-light text-zinc-600 transition-colors hover:text-zinc-400"
+        >
+          buy me a coffee ☕
+        </a>
+      </div>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Merge dans `main` un lot de bumps Dependabot validés localement.

- #40 posthog-js 1.372.3 → 1.372.8 (frontend, patch)
- #41 posthog-node 5.30 → 5.33 + msw 2.13 → 2.14 (backend, minor/patch)
- #43 @fastify/cors 10 → 11 (backend, major) — pas d'impact, options passées explicitement dans app.ts:57
- #47 @types/node 22 → 25 (backend devDep) — runtime Railway reste Node 22, build TS clean

## Test plan

- [x] PR #40 : lint + build frontend OK
- [x] PR #41 : 305/305 tests backend
- [x] PR #43 : 305/305 tests backend, build, lint
- [x] PR #47 : 305/305 tests backend, tsc clean

## Reste hors scope

- #42 pino-pretty 13.x — en cours (rebase post-merge en attente)
- #44 eslint 10 — fermée (incompat eslint-config-next)
- #45 jose 6 — à valider séparément (auth-critique)
- #46 recharts 3 — fermée (migration manuelle requise)