### PR TITLE
ci(dependabot): auto-approve minor/patch PRs before auto-merge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,6 +15,14 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v3
 
+      - name: Approve minor and patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Auto-merge minor and patch updates
         if: |
           steps.metadata.outputs.update-type == 'version-update:semver-minor' ||


### PR DESCRIPTION
Le ruleset de branche main exige une review approuvante avant merge, ce qui bloquait l'auto-merge des PR Dependabot meme quand CI passait.