### PR TITLE
feat: surface hosting cost and donation link

### DIFF
--- a/backend/src/modules/stremio/stremio.service.ts
+++ b/backend/src/modules/stremio/stremio.service.ts
@@ -285,7 +285,7 @@ export function generateBaseManifest(): StremioManifest {
     id: 'community.stremboxd',
     version: '1.2.3',
     name: 'Stremboxd',
-    description: 'Letterboxd for Stremio: popular films, Top 250, watchlist, custom lists, genre & decade filters, and search. Configure at https://stremboxd.com',
+    description: 'Letterboxd for Stremio: popular films, Top 250, watchlist, custom lists, genre & decade filters, and search. Configure at https://stremboxd.com. Free forever — donations welcome: https://buymeacoffee.com/esp4ce',
     logo: `${config.PUBLIC_URL}/logo.png`,
     background: `${config.PUBLIC_URL}/background.jpg`,
     resources: [
@@ -464,7 +464,7 @@ export function generatePublicManifest(
     id: 'community.stremboxd',
     version: '1.2.3',
     name: `Stremboxd${namePart}`,
-    description: 'Letterboxd for Stremio: popular films, Top 250, watchlist, custom lists, genre & decade filters, and search. Configure at https://stremboxd.com',
+    description: 'Letterboxd for Stremio: popular films, Top 250, watchlist, custom lists, genre & decade filters, and search. Configure at https://stremboxd.com. Free forever — donations welcome: https://buymeacoffee.com/esp4ce',
     logo: `${config.PUBLIC_URL}/logo.png`,
     background: `${config.PUBLIC_URL}/background.jpg`,
     resources: [

--- a/src/app/components/ConsoleMessage.tsx
+++ b/src/app/components/ConsoleMessage.tsx
@@ -13,7 +13,7 @@ const CONSOLE_STYLES = {
 const CONSOLE_LINKS = [
   { label: "GitHub", url: "https://github.com/esp4ce" },
   { label: "Reddit", url: "https://www.reddit.com/r/stremboxd/", desc: "(Support & Community)" },
-  { label: "Support", url: "https://buymeacoffee.com/esp4ce", desc: "(Buy me a coffee)" },
+  { label: "Support", url: "https://buymeacoffee.com/esp4ce", desc: "(hosting costs ~$14/month)" },
 ];
 
 /**

--- a/src/app/configure/ConfigurationModal.tsx
+++ b/src/app/configure/ConfigurationModal.tsx
@@ -792,16 +792,16 @@ export default function ConfigurationModal(props: ConfigurationModalProps) {
             </button>
 
             <p className="mt-4 text-center text-xs text-zinc-500">
-              Enjoying Stremboxd?{" "}
+              Hosting costs ~$14/month —{" "}
               <a
                 href="https://buymeacoffee.com/esp4ce"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-zinc-400 underline underline-offset-2 transition-colors hover:text-zinc-200"
               >
-                Buy me a coffee ☕
+                buy me a coffee ☕
               </a>{" "}
-              — it keeps the servers running.
+              if you'd like to help keep it running.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add donation link + "free forever" note to the Stremio manifest description (Tier 1 & Tier 2)
- Show approximate hosting cost (~$14/month) next to the Buy Me a Coffee link on the configure page and in the console easter egg

## Test plan
- [ ] Verify /manifest.json description includes the donation line
- [ ] Verify /configure page shows updated cost text under Save & Install
- [ ] Verify browser console message shows updated Support line